### PR TITLE
Add debugging infrastructure

### DIFF
--- a/pg_stat_plans.c
+++ b/pg_stat_plans.c
@@ -838,6 +838,12 @@ pgsp_ExecutorEnd(QueryDesc *queryDesc)
 		if (pgsp_planid_notice)
 			ereport(NOTICE,
 					(errmsg("planid: %u", planId)));
+
+#ifdef STAT_PLANS_DEBUG
+		/* Pretty-print tree */
+		printf("Dumping plan %u after plan_store", planId);
+		pprint(queryDesc->plannedstmt);
+#endif
 	}
 
 	/* ...xor explain a query */
@@ -860,6 +866,12 @@ pgsp_ExecutorEnd(QueryDesc *queryDesc)
 		MemoryContextSwitchTo(mct);
 
 		pgsp_explaining = PGSP_NO_EXPLAIN;
+
+#ifdef STAT_PLANS_DEBUG
+		/* Pretty-print tree */
+		printf("Dumping plan %u after explaining", pgsp_planid);
+		pprint(queryDesc->plannedstmt);
+#endif
 	}
 
 	if (prev_ExecutorEnd)


### PR DESCRIPTION
This infrastructure can be used to debug problems with pg_stat_plans
fingerprinting logic. When the macro STATS_PLAN_DEBUG is defined, Postgres will
print a low-level representation of each plan tree that is fingerprinted, as it
is fingerprinted.

Add documentation on how to debug problems with pg_stat_plans' fingerprinting
logic, including using this new infrastructure.
