### PR TITLE
Fix backend crash in case an empty search_path was set.

### DIFF
--- a/pg_stat_plans.c
+++ b/pg_stat_plans.c
@@ -1608,7 +1608,7 @@ static Oid
 get_search_path_xor(void)
 {
 	bool		 skip_first = true;
-	List		*search_path = fetch_search_path(false);
+	List		*search_path = fetch_search_path(true);
 	Oid			 res = linitial_oid(search_path);
 	ListCell	*lc;
 


### PR DESCRIPTION
This could happen in case a database session has set a search_path
to a schema not accessible by the current role for example.
This results in an empty activeSearchPath list, which is returned by
fetch_search_path() as an empty list. Access in get_search_path_xor()
then causes a crash.

The best solution to this seems to also include any implicit search_path
members, too. This also seems to be a more correct definition in the sense
of a "stable" view when evaluating the plans later.
