### PR TITLE
catalog/pg_collation.h is only available in >= 9.1

### DIFF
--- a/pg_stat_plans.c
+++ b/pg_stat_plans.c
@@ -36,7 +36,6 @@
 #include "access/hash.h"
 #include "executor/instrument.h"
 #include "catalog/namespace.h"
-#include "catalog/pg_collation.h"
 #include "commands/explain.h"
 #include "executor/spi.h"
 #include "funcapi.h"
@@ -52,6 +51,9 @@
 #include "utils/formatting.h"
 #include "utils/memutils.h"
 
+#if PG_VERSION_NUM >= 90100
+#include "catalog/pg_collation.h"
+#endif
 
 PG_MODULE_MAGIC;
 


### PR DESCRIPTION
This fixes a build error when compiling against Postgres 9.0. Haven't done functional tests against 9.0 yet, so handle with care.
